### PR TITLE
Add missing @api.model decorator to FSMOrder.create() override

### DIFF
--- a/fieldservice_sale/models/fsm_order.py
+++ b/fieldservice_sale/models/fsm_order.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Brian McMaster
 # Copyright (C) 2019 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 
 class FSMOrder(models.Model):
@@ -27,6 +27,7 @@ class FSMOrder(models.Model):
                 vals.update({"customer_id": order.sale_id.partner_id.id})
         return super(FSMOrder, self).write(vals)
 
+    @api.model
     def create(self, vals):
         sale_id = self.env["sale.order"].browse(vals.get("sale_id"))
         if sale_id:


### PR DESCRIPTION
The @api.model decorator should be preserved on overloaded methods